### PR TITLE
Feature/permissions scheme

### DIFF
--- a/database_scheme.md
+++ b/database_scheme.md
@@ -44,6 +44,7 @@ mindenkinek egy dokumentum.
   a projekt id-je, az érték az eddig megszerzett mancsok száma.
 - `role` (String): A felhasználó szerepe. Értékkészlete a [Role](#role) enum értékei.
 - `mokStatus` (String): A felhasználó egyesületi státusza. Értékkészlete: `MÖK`, `UP`, `PreMÖK`, `Holdudvar`, `Alumni`, `Pártoló`, `Külsős`. 
+- `permissions`: (List(String)): A felhasználó jogosultságai. Tartalmazhat terület (Category enum), projekt és pecsét id-t is.
 
 ## rewards
 


### PR DESCRIPTION
Új rendszer a jogosultságoknak. A permissions tömb-ben lehet:
- projekt id: mindent, amit a projekt vezetője is tud
- terület id: hasonlóan, csak minden projekthez az adott területen
- pecsét id: oszthatsz az adott pecsétből bárkinek

Így nem kell külön területvezető/projektvezetőhelyettes/pecsétfelelős stb. mezőt kezelni. A jelenlegi jogosultságokból ez nem venne el semmit, tehát admin és projektvezető dolog maradna.